### PR TITLE
Potential fix for code scanning alert no. 89: Uncontrolled data used in path expression

### DIFF
--- a/server/src/services/BackupService.ts
+++ b/server/src/services/BackupService.ts
@@ -195,6 +195,14 @@ class BackupService {
     comment?: string,
     taskId?: string
   ) {
+    // Ensure the temporary upload path is within the expected temp directory.
+    const tempRoot = path.resolve(process.cwd(), 'data', 'temp');
+    const resolvedTempPath = path.resolve(tempPath);
+    if (!resolvedTempPath.startsWith(tempRoot + path.sep)) {
+      throw new Error('Invalid temporary upload path');
+    }
+    const safeTempPath = resolvedTempPath;
+
     const safeServerId = serverId.toString().replace(/[^a-zA-Z0-9]/g, '');
     const id = Date.now().toString();
     const filename = `backup_${safeServerId}_${id}.zip`;
@@ -205,8 +213,8 @@ class BackupService {
         taskService.updateTask(taskId, { progress: 50, message: 'tasks.messages.moving_files' });
 
       // Move temp file to backup directory
-      fs.copyFileSync(tempPath, targetPath);
-      fs.unlinkSync(tempPath);
+      fs.copyFileSync(safeTempPath, targetPath);
+      fs.unlinkSync(safeTempPath);
 
       const stats = fs.statSync(targetPath);
       db.prepare(
@@ -215,7 +223,7 @@ class BackupService {
 
       return id;
     } catch (error) {
-      if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      if (fs.existsSync(safeTempPath)) fs.unlinkSync(safeTempPath);
       if (fs.existsSync(targetPath)) fs.unlinkSync(targetPath);
       throw error;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cspamsky/quatrix-cs2/security/code-scanning/89](https://github.com/cspamsky/quatrix-cs2/security/code-scanning/89)

General approach: treat `tempPath` as untrusted and ensure it is constrained to a known-safe directory before using it in file operations. This follows the “safe root folder + normalized path” pattern described in the background: resolve the real path, verify it lives under the intended temp directory, and only then copy/unlink.

Best concrete fix here:

1. Define the expected temp upload directory using `path.resolve(process.cwd(), 'data', 'temp')`, matching the `multer({ dest: 'data/temp/' })` configuration.
2. For the provided `tempPath`, compute its absolute path (e.g., `path.resolve(tempPath)`), optionally normalize via `fs.realpathSync` in a guarded way.
3. Check that this resolved path starts with the temp root (with a separator-aware check to avoid `/data/tempX` matching `/data/temp`).
4. If the check fails, throw an error before calling `fs.copyFileSync` or `fs.unlinkSync`.
5. Use this validated path for all subsequent operations (copy, unlink, existsSync).

This change is localized to `BackupService.handleExternalUpload` in `server/src/services/BackupService.ts`. No changes are required in `server/src/routes/backups.ts`. We will:

- Add a small helper snippet inline in `handleExternalUpload` to resolve and validate `tempPath` into `safeTempPath`.
- Replace all uses of `tempPath` in that method with `safeTempPath`.
- Use existing `fs` and `path` imports; no new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
