### PR TITLE
Potential fix for code scanning alert no. 87: Uncontrolled data used in path expression

### DIFF
--- a/server/src/services/BackupService.ts
+++ b/server/src/services/BackupService.ts
@@ -34,9 +34,11 @@ interface ServerRow {
 
 class BackupService {
   private backupDir: string;
+  private tempDir: string;
 
   constructor() {
     this.backupDir = path.join(process.cwd(), 'data', 'backups');
+    this.tempDir = path.join(process.cwd(), 'data', 'temp');
     this.init();
   }
 
@@ -196,7 +198,13 @@ class BackupService {
     taskId?: string
   ) {
     const safeServerId = serverId.toString().replace(/[^a-zA-Z0-9]/g, '');
+    const resolvedTempPath = path.resolve(tempPath);
     const id = Date.now().toString();
+    // Ensure the temporary path is within the expected temp directory
+    if (!resolvedTempPath.startsWith(this.tempDir + path.sep)) {
+      throw new Error('Invalid temporary upload path');
+    }
+
     const filename = `backup_${safeServerId}_${id}.zip`;
     const targetPath = path.resolve(this.backupDir, filename);
 
@@ -205,8 +213,8 @@ class BackupService {
         taskService.updateTask(taskId, { progress: 50, message: 'tasks.messages.moving_files' });
 
       // Move temp file to backup directory
-      fs.copyFileSync(tempPath, targetPath);
-      fs.unlinkSync(tempPath);
+      fs.copyFileSync(resolvedTempPath, targetPath);
+      fs.unlinkSync(resolvedTempPath);
 
       const stats = fs.statSync(targetPath);
       db.prepare(
@@ -215,7 +223,7 @@ class BackupService {
 
       return id;
     } catch (error) {
-      if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      if (fs.existsSync(resolvedTempPath)) fs.unlinkSync(resolvedTempPath);
       if (fs.existsSync(targetPath)) fs.unlinkSync(targetPath);
       throw error;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cspamsky/quatrix-cs2/security/code-scanning/87](https://github.com/cspamsky/quatrix-cs2/security/code-scanning/87)

In general, to fix uncontrolled path usage you must constrain user-controlled paths to an expected directory or format. For paths that may include directories, compute an absolute, normalized path and ensure it resides within a known “root” directory before using it in filesystem operations.

Here, the unsafe value is `tempPath` in `BackupService.handleExternalUpload`. It originates from `multer`’s temp file, which should live in `data/temp/`. The safest, minimal-change fix is:

- Derive the intended temp upload directory (e.g. `path.join(process.cwd(), 'data', 'temp')`) in `BackupService`, similar to how `backupDir` is set.
- Before calling `fs.copyFileSync` or `fs.unlinkSync` on `tempPath`, normalize it with `path.resolve` and verify that the resolved path starts with this temp directory path (and possibly still exists and is a file).
- If `tempPath` does not resolve under the allowed temp directory, throw an error and do not perform any filesystem operations on it.

This keeps existing functionality (moving the multer temp file into the backup directory) but adds a safety check and satisfies CodeQL. Concretely, in `server/src/services/BackupService.ts`:

1. Add a `private tempDir: string;` field to `BackupService` and initialize it in the constructor: `this.tempDir = path.join(process.cwd(), 'data', 'temp');`.
2. In `handleExternalUpload`, compute `const resolvedTempPath = path.resolve(tempPath);` and check it: if it does not start with `this.tempDir + path.sep`, throw an error.
3. Use `resolvedTempPath` instead of `tempPath` in `copyFileSync`, `unlinkSync`, and the `existsSync` checks in the catch block.

No new imports are needed; `path` and `fs` are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
