### PR TITLE
Potential fix for code scanning alert no. 86: Uncontrolled data used in path expression

### DIFF
--- a/server/src/services/BackupService.ts
+++ b/server/src/services/BackupService.ts
@@ -200,13 +200,21 @@ class BackupService {
     const filename = `backup_${safeServerId}_${id}.zip`;
     const targetPath = path.resolve(this.backupDir, filename);
 
+    // Ensure the temporary path is within the expected uploads temp directory
+    const tempRoot = fs.realpathSync(path.resolve(process.cwd(), 'data', 'temp'));
+    const resolvedTempPath = fs.realpathSync(tempPath);
+    const tempRootWithSep = tempRoot.endsWith(path.sep) ? tempRoot : tempRoot + path.sep;
+    if (!resolvedTempPath.startsWith(tempRootWithSep)) {
+      throw new Error('Invalid temporary upload path');
+    }
+
     try {
       if (taskId)
         taskService.updateTask(taskId, { progress: 50, message: 'tasks.messages.moving_files' });
 
       // Move temp file to backup directory
-      fs.copyFileSync(tempPath, targetPath);
-      fs.unlinkSync(tempPath);
+      fs.copyFileSync(resolvedTempPath, targetPath);
+      fs.unlinkSync(resolvedTempPath);
 
       const stats = fs.statSync(targetPath);
       db.prepare(
@@ -215,7 +223,7 @@ class BackupService {
 
       return id;
     } catch (error) {
-      if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      if (fs.existsSync(resolvedTempPath)) fs.unlinkSync(resolvedTempPath);
       if (fs.existsSync(targetPath)) fs.unlinkSync(targetPath);
       throw error;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cspamsky/quatrix-cs2/security/code-scanning/86](https://github.com/cspamsky/quatrix-cs2/security/code-scanning/86)

In general, to fix uncontrolled path issues when dealing with files uploaded to a temporary directory, you should ensure that any path you operate on is (a) normalized/resolved and (b) verified to be inside a known safe root directory. For temporary upload files managed by a library such as `multer`, you can compute the real path of the expected temp directory, compute the real path of the provided `tempPath`, and then check that the latter starts with the former. If the check fails, treat it as an invalid upload and abort before performing any filesystem operations.

The best way to fix this specific case without changing existing functionality is to add a validation step in `BackupService.handleExternalUpload` right before using `tempPath`. We can resolve `tempPath` via `fs.realpathSync`, resolve the expected temp directory via `fs.realpathSync(path.resolve(process.cwd(), 'data', 'temp'))`, and then ensure the resolved `tempPath` starts with the resolved temp root (with a trailing path separator to avoid prefix tricks). If the validation fails, we throw an error and skip `copyFileSync` and `unlinkSync`. If it passes, we use the validated, resolved path for subsequent operations. Since `path` and `fs` are already imported in `BackupService.ts`, no new imports are required. No changes are needed in `server/src/routes/backups.ts`.

Concretely:
- In `handleExternalUpload`:
  - Introduce a `tempRoot` and `resolvedTempPath` computation near the start of the method, before the `try` block.
  - Add a conditional that checks `resolvedTempPath.startsWith(tempRootWithSep)` and throws if it does not.
  - Use `resolvedTempPath` instead of `tempPath` in `copyFileSync`, `unlinkSync`, and the cleanup logic in the `catch` block.
This preserves existing behavior when `multer` behaves as expected, adds a safety net if a nonconforming path is ever passed in, and satisfies the static analysis requirement by bounding the path to a known directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
