### PR TITLE
Potential fix for code scanning alert no. 88: Uncontrolled data used in path expression

### DIFF
--- a/server/src/services/BackupService.ts
+++ b/server/src/services/BackupService.ts
@@ -195,6 +195,13 @@ class BackupService {
     comment?: string,
     taskId?: string
   ) {
+    // Ensure the temporary upload path is within the expected temp directory
+    const tempRoot = path.resolve(process.cwd(), 'data', 'temp');
+    const resolvedTempPath = path.resolve(tempPath);
+    if (resolvedTempPath !== tempRoot && !resolvedTempPath.startsWith(tempRoot + path.sep)) {
+      throw new Error('Invalid temporary upload path');
+    }
+
     const safeServerId = serverId.toString().replace(/[^a-zA-Z0-9]/g, '');
     const id = Date.now().toString();
     const filename = `backup_${safeServerId}_${id}.zip`;
@@ -205,8 +212,8 @@ class BackupService {
         taskService.updateTask(taskId, { progress: 50, message: 'tasks.messages.moving_files' });
 
       // Move temp file to backup directory
-      fs.copyFileSync(tempPath, targetPath);
-      fs.unlinkSync(tempPath);
+      fs.copyFileSync(resolvedTempPath, targetPath);
+      fs.unlinkSync(resolvedTempPath);
 
       const stats = fs.statSync(targetPath);
       db.prepare(
@@ -215,7 +222,7 @@ class BackupService {
 
       return id;
     } catch (error) {
-      if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      if (fs.existsSync(resolvedTempPath)) fs.unlinkSync(resolvedTempPath);
       if (fs.existsSync(targetPath)) fs.unlinkSync(targetPath);
       throw error;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cspamsky/quatrix-cs2/security/code-scanning/88](https://github.com/cspamsky/quatrix-cs2/security/code-scanning/88)

General approach: When using a path that originates from user-controllable data (directly or indirectly), constrain it to a known safe directory. Normalize the path (e.g., with `path.resolve`) and verify that it resides inside the expected root directory (e.g., the multer temp upload directory). If the check fails, abort the operation and clean up safely.

Best fix here: Inside `BackupService.handleExternalUpload`, derive the expected temp upload directory (in this codebase, `data/temp` relative to `process.cwd()`), normalize `tempPath` with `path.resolve`, and ensure the resulting path is inside the temp directory using a prefix check that accounts for path separators. If the check fails, throw an error before calling any `fs.*` APIs with `tempPath`. This leaves existing behavior unchanged when `tempPath` is legitimate, and hardens the code against any misuse or future misconfigurations.

Concretely:
- In `server/src/services/BackupService.ts`, in `handleExternalUpload`, just after the method parameters and before using `tempPath`, add:
  - `const tempRoot = path.resolve(process.cwd(), 'data', 'temp');`
  - `const resolvedTempPath = path.resolve(tempPath);`
  - A check that `resolvedTempPath` starts with `tempRoot + path.sep` or equals `tempRoot`. If not, throw an error.
- Replace all later uses of `tempPath` in this method (`copyFileSync`, `unlinkSync`, `existsSync`) with `resolvedTempPath` so that only the validated/normalized path is used.
- No changes are required in `server/src/routes/backups.ts`, as it already uses `multer` with a fixed `dest`.

This keeps functionality the same for valid uploads but enforces that only files within `data/temp` are ever used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
